### PR TITLE
Add initial audio api & tests

### DIFF
--- a/src/gameboy/alu.rs
+++ b/src/gameboy/alu.rs
@@ -1,0 +1,45 @@
+pub struct ALU {
+    buffer: Vec<i16>,
+    cycles_to_next_sample: i32,
+}
+
+const SAMPLE_RATE: i32 = 48000; // Hz
+const CYCLES_PER_SECOND: i32 = 4194304;
+const SAMPLES_PER_FRAME: i32 = SAMPLE_RATE / 60; // 800
+const CYCLES_PER_SAMPLE: i32 = CYCLES_PER_SECOND / (60 * SAMPLES_PER_FRAME);
+
+impl ALU {
+    pub fn new() -> ALU {
+        let mut buffer = Vec::new();
+        buffer.reserve(SAMPLES_PER_FRAME as usize + 3);
+        ALU {
+            buffer,
+            cycles_to_next_sample: CYCLES_PER_SAMPLE,
+        }
+    }
+
+    pub fn tick(&mut self, tick: u32, _memory: &mut Vec<u8>) {
+        // decrease the cycles_to_next_sample
+        self.cycles_to_next_sample = self.cycles_to_next_sample - tick as i32;
+
+        // if the cycles are less than 0 then emit a value, reset the count
+        if self.cycles_to_next_sample <= 0 {
+            if self.buffer.len() >= 803 {
+                self.buffer.clear();
+            }
+
+            self.buffer.push(0);
+            self.cycles_to_next_sample = CYCLES_PER_SAMPLE + self.cycles_to_next_sample;
+        }
+    }
+
+    pub fn get_sample(&self) -> Vec<i16> {
+        if self.buffer.len() > 8 {
+            let mut result = vec![0; 800];
+            result.copy_from_slice(&self.buffer[0..800]);
+            result
+        } else {
+            self.buffer.clone()
+        }
+    }
+}

--- a/src/gameboy/mod.rs
+++ b/src/gameboy/mod.rs
@@ -1,3 +1,4 @@
+mod alu;
 mod cpu;
 mod flags_register;
 mod gameboy;

--- a/src/gameboy/tests/alu_test.rs
+++ b/src/gameboy/tests/alu_test.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod alu_test {
+    use super::super::tests::infinite_loop_gb;
+    use rust_catch::tests;
+
+    tests! {
+        test("Run the gameboy for a frame and get a frame of audio") {
+            let mut gb = infinite_loop_gb();
+
+            // Run the gameboy for a frame
+            let breakpoints = vec![];
+            gb.tick(1.0 / 60.0, &breakpoints);
+
+            let sample = gb.get_sample();
+            assert!(sample.iter().all(|val| *val == 0));
+
+            assert_eq!(sample.len(), 800);
+        }
+
+        test("Run into the next frame and the buffer is cleared") {
+            let mut gb = infinite_loop_gb();
+
+            let breakpoints = vec![];
+            gb.tick(1.0 / 60.0, &breakpoints);
+
+            // This should put us onto the next frame
+            for _ in 0..6 { // Run through at least 87 frames
+                gb.step_once();
+                gb.step_once();
+            }
+
+            let sample = gb.get_sample();
+            assert_eq!(sample.len(), 1);
+        }
+    }
+}

--- a/src/gameboy/tests/mod.rs
+++ b/src/gameboy/tests/mod.rs
@@ -1,3 +1,4 @@
+mod alu_test;
 mod cp_test;
 mod dec_test;
 mod inc_test;
@@ -10,6 +11,19 @@ mod ppu_test;
 mod ret_test;
 mod sub_test;
 mod timing;
+
+#[cfg(test)]
+mod tests {
+    use crate::gameboy::Gameboy;
+
+    pub fn infinite_loop_gb() -> Gameboy {
+        // Each loop will be 16 clocks & take 2 steps
+        // NOP
+        // JR -3
+        let gb = Gameboy::new(vec![0x00, 0x18, 0xFD]);
+        gb
+    }
+}
 
 #[cfg(test)]
 mod opcode_tests {


### PR DESCRIPTION
Add an audio (ALU) class to handle audio generation. ALU currently only generates 0's but is tested to only create buffers of 800 samples per frame.

At the moment the target sample rate is 48,000 Hz with 800 samples being generated per frame. Currently only targeting Square 1 channel to get bootloader working